### PR TITLE
chore: bootstrap package + npm install

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -1,0 +1,28 @@
+name: Publish to npm
+
+# Controls when the action will run.  
+# In this case, I'm saying on each release event when it's specifically a new release publish, the types: [published] is required here, 
+# since releases could also be updated or deleted, we only want to publish to npm when a new release is created (published).
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+    #Install Node.js, with the version 14 and using the registry URL of npm, this could be changed to a custom registry or the GitHub registry.
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 14
+        registry-url: https://registry.npmjs.org/
+
+    # Command to install the package dependencies
+    - run: yarn install
+      
+    # Publish to npm
+    - run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+ 
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+ 
+## [Unreleased] - yyyy-mm-dd
+ 
+Here we write upgrading notes for brands. It's a team effort to make them as
+straightforward as possible.
+ 
+ 

--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b7e83138dc5ed405b9a81e345d96f3b5
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation~/com.onesignal.unity.bootstrap.md
+++ b/Documentation~/com.onesignal.unity.bootstrap.md
@@ -1,0 +1,1 @@
+Full documentation avaliable at  [documentation.onesignal.com](https://documentation.onesignal.com/docs/unity-sdk-setup)

--- a/Editor.meta
+++ b/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a08ee4b66bd5a42c9a4531f6c9c792c8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Bootstrapper.cs
+++ b/Editor/Bootstrapper.cs
@@ -1,0 +1,60 @@
+﻿using UnityEditor;
+
+namespace Com.OneSignal.Bootstrapper
+{
+    [InitializeOnLoad]
+    static class Bootstrapper
+    {
+        static Bootstrapper()
+        {
+            var manifest = new Manifest();
+            manifest.Fetch();
+
+            var manifestUpdated = false;
+
+            if (!manifest.IsRegistryExists(BootstrapperConfig.NpmjsScopeRegistryUrl))
+            {
+                manifest.AddScopeRegistry(BootstrapperConfig.NpmjsScopeRegistry);
+                manifestUpdated = true;
+            }
+            else
+            {
+                var npmjsScopeRegistry = manifest.GetScopeRegistry(BootstrapperConfig.NpmjsScopeRegistryUrl);
+                if (!npmjsScopeRegistry.HasScope(BootstrapperConfig.OneSignalScope))
+                {
+                    npmjsScopeRegistry.AddScope(BootstrapperConfig.OneSignalScope);
+                    manifestUpdated = true;
+                }
+            }
+
+            // UnityEditor.PackageManager.Client.Add method doesn't work in Unity versions older then 2019.
+            // Thus, we need to manually add dependencies.
+            // Probably we need to make something similar to OneSignalUpdateRequest to get the latest package version.
+
+            if (!manifest.IsDependencyExists(BootstrapperConfig.OneSignalCoreName))
+            {
+                manifest.AddDependency(BootstrapperConfig.OneSignalCoreName, BootstrapperConfig.OneSignalCoreVersion);
+                manifestUpdated = true;
+            }
+
+            if (!manifest.IsDependencyExists(BootstrapperConfig.OneSignalAndroidName))
+            {
+                manifest.AddDependency(BootstrapperConfig.OneSignalAndroidName, BootstrapperConfig.OneSignalAndroidVersion);
+                manifestUpdated = true;
+            }
+
+            if (!manifest.IsDependencyExists(BootstrapperConfig.OneSignalIOSName))
+            {
+                manifest.AddDependency(BootstrapperConfig.OneSignalIOSName, BootstrapperConfig.OneSignalIosVersion);
+                manifestUpdated = true;
+            }
+
+            if (manifestUpdated)
+            {
+                manifest.ApplyChanges();
+            }
+
+            UnityEditor.PackageManager.Client.Remove(BootstrapperConfig.BootstrapperPackageName);
+        }
+    }
+}

--- a/Editor/Bootstrapper.cs.meta
+++ b/Editor/Bootstrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 238dc708779b2b444aa1a687e1e73f45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/BootstrapperConfig.cs
+++ b/Editor/BootstrapperConfig.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+
+namespace Com.OneSignal.Bootstrapper
+{
+    static class BootstrapperConfig
+    {
+        public static readonly string OneSignalScope = "com.onesignal.unity";
+        public static readonly string BootstrapperPackageName = "com.onesignal.unity.bootstrap";
+
+        public static readonly string OneSignalCoreName = "com.onesignal.unity.core";
+        public static readonly string OneSignalCoreVersion = "0.0.1";
+
+        public static readonly string OneSignalIOSName = "com.onesignal.unity.ios";
+        public static readonly string OneSignalIosVersion = "0.0.1";
+
+        public static readonly string OneSignalAndroidName = "com.onesignal.unity.android";
+        public static readonly string OneSignalAndroidVersion = "0.0.1";
+
+        public static readonly string GoogleScopeRegistryUrl = "https://unityregistry-pa.googleapis.com";
+        public static readonly string NpmjsScopeRegistryUrl = "https://registry.npmjs.org/";
+
+        public static ScopeRegistry GoogleScopeRegistry =>
+            new ScopeRegistry("Game Package Registry by Google",
+                GoogleScopeRegistryUrl,
+                new HashSet<string>
+                {
+                    "com.google"
+                });
+
+        public static ScopeRegistry NpmjsScopeRegistry =>
+            new ScopeRegistry("npmjs",
+                NpmjsScopeRegistryUrl,
+                new HashSet<string>
+                {
+                    OneSignalScope
+                });
+    }
+}

--- a/Editor/BootstrapperConfig.cs.meta
+++ b/Editor/BootstrapperConfig.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0f4ee691c4394e1a928bfad503601707
+timeCreated: 1589386540

--- a/Editor/Com.OneSignal.Bootstrap.asmdef
+++ b/Editor/Com.OneSignal.Bootstrap.asmdef
@@ -1,0 +1,15 @@
+{
+    "name": "Com.OneSignal.Bootstrapper",
+    "references": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Editor/Com.OneSignal.Bootstrap.asmdef.meta
+++ b/Editor/Com.OneSignal.Bootstrap.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 56c33ba5db9cc47e89dd4a10447aec93
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Core.meta
+++ b/Editor/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: be6452b1916dcfd48823884aad74bcde
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Core/Dependency.cs
+++ b/Editor/Core/Dependency.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+
+namespace Com.OneSignal.Bootstrapper
+{
+    /// <summary>
+    /// Representation of the manifest file "dependency" entry.
+    /// </summary>
+    class Dependency
+    {
+        /// <summary>
+        /// The dependency name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The dependency version.
+        /// </summary>
+        public string Version { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the  <see cref="Dependency"/> class with provided properties.
+        /// </summary>
+        /// <param name="name">Dependency name.</param>
+        /// <param name="version">Dependency version.</param>
+        public Dependency(string name, string version)
+        {
+            Name = name;
+            Version = version;
+        }
+
+        /// <summary>
+        /// Sets new dependency version.
+        /// </summary>
+        /// <param name="version">The version to be set for this dependency</param>
+        public void SetVersion(string version)
+        {
+            Version = version;
+        }
+
+        /// <summary>
+        /// Creates a dictionary from this object.
+        /// </summary>
+        /// <returns>Dependency object representation as Dictionary&lt;string, object&gt;.</returns>
+        public Dictionary<string, object> ToDictionary()
+        {
+            Dictionary<string,object> result = new Dictionary<string, object>();
+            result.Add(Name, Version);
+            return result;
+        }
+    }
+}

--- a/Editor/Core/Dependency.cs.meta
+++ b/Editor/Core/Dependency.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e52fbcfa27454254814d217fe8ffc209
+timeCreated: 1589382189

--- a/Editor/Core/Manifest.cs
+++ b/Editor/Core/Manifest.cs
@@ -1,0 +1,166 @@
+using System.Collections.Generic;
+using System.IO;
+using OneSignalPush.MiniJSON;
+
+namespace Com.OneSignal.Bootstrapper
+{
+    /// <summary>
+    /// Representation of Manifest JSON file.
+    /// Can be used for adding dependencies, scopeRegistries, etc to .json file
+    /// </summary>
+    class Manifest
+    {
+        const string k_ProjectManifestPath = "Packages/manifest.json";
+        const string k_DependenciesKey = "dependencies";
+        const string k_ScopedRegistriesKey = "scopedRegistries";
+
+        /// <summary>
+        /// Path to manifest file.
+        /// </summary>
+        public string Path { get; }
+
+        readonly Dictionary<string, ScopeRegistry> m_ScopeRegistries;
+        readonly Dictionary<string, Dependency> m_Dependencies;
+
+        Dictionary<string, object> m_RawContent;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Manifest"/> class.
+        /// </summary>
+        /// <param name="pathToFile">Path to manifest file.</param>
+        public Manifest(string pathToFile = k_ProjectManifestPath)
+        {
+            Path = pathToFile;
+            m_ScopeRegistries = new Dictionary<string, ScopeRegistry>();
+            m_Dependencies = new Dictionary<string,Dependency>();
+        }
+
+        /// <summary>
+        /// Read the Manifest file and deserialize its content from JSON.
+        /// </summary>
+        public void Fetch()
+        {
+            var manifestText = File.ReadAllText(Path);
+            m_RawContent = (Dictionary<string, object>)Json.Deserialize(manifestText);
+
+            if (m_RawContent.TryGetValue(k_ScopedRegistriesKey, out var registriesBlob))
+            {
+                if (registriesBlob is List<object> registries)
+                {
+                    foreach (var registry in registries)
+                    {
+                        var registryDict = (Dictionary<string, object>)registry;
+                        var scopeRegistry = new ScopeRegistry(registryDict);
+                        m_ScopeRegistries.Add(scopeRegistry.Url, scopeRegistry);
+                    }
+                }
+            }
+
+            if (m_RawContent.TryGetValue(k_DependenciesKey, out var dependenciesBlob))
+            {
+                if (dependenciesBlob is Dictionary<string, object> dependencies)
+                {
+                    foreach (var dependencyData in dependencies)
+                    {
+                        var dependency = new Dependency(dependencyData.Key, dependencyData.Value.ToString());
+                        m_Dependencies.Add(dependency.Name, dependency);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns dependency by a provided name.
+        /// </summary>
+        /// <param name="name">Name of the dependency.</param>
+        /// <returns>Dependency with given name.</returns>
+        public Dependency GetDependency(string name)
+        {
+            return m_Dependencies[name];
+        }
+
+        /// <summary>
+        /// Returns scope registry by a provided url.
+        /// </summary>
+        /// <param name="url">Scope registry url.</param>
+        /// <returns>Scope registry with the given url.</returns>
+        public ScopeRegistry GetScopeRegistry(string url)
+        {
+            return m_ScopeRegistries[url];
+        }
+
+        /// <summary>
+        /// Adds scope registry.
+        /// </summary>
+        /// <param name="registry">An entry to add.</param>
+        public void AddScopeRegistry(ScopeRegistry registry)
+        {
+            if (!IsRegistryExists(registry.Url))
+            {
+                m_ScopeRegistries.Add(registry.Url, registry);
+            }
+        }
+
+        /// <summary>
+        /// Adds dependency.
+        /// </summary>
+        /// <param name="name">Dependency name.</param>
+        /// <param name="version">Dependency version.</param>
+        public void AddDependency(string name, string version)
+        {
+            if (!IsDependencyExists(name))
+            {
+                var dependency = new Dependency(name, version);
+                m_Dependencies.Add(dependency.Name, dependency);
+            }
+        }
+
+        /// <summary>
+        /// Writes changes back to the manifest file.
+        /// </summary>
+        public void ApplyChanges()
+        {
+            var registries = new List<object>();
+            foreach (var registry in m_ScopeRegistries.Values)
+            {
+                registries.Add(registry.ToDictionary());
+            }
+            m_RawContent[k_ScopedRegistriesKey] = registries;
+
+            // Remove 'scopedRegistries' key from raw content if we have zero scope registries.
+            // Because we don't need an empty 'scopedRegistries' key in the manifest
+            if (registries.Count == 0)
+                m_RawContent.Remove(k_ScopedRegistriesKey);
+
+            Dictionary<string,object> dependencies = new Dictionary<string, object>();
+            foreach (var dependency in m_Dependencies.Values)
+            {
+                dependencies.Add(dependency.Name, dependency.Version);
+            }
+            m_RawContent[k_DependenciesKey] = dependencies;
+
+            string manifestText = Json.Serialize(m_RawContent, true);
+            File.WriteAllText(Path,manifestText);
+        }
+
+        /// <summary>
+        /// Searches for ScopeRegistry with the provided Url.
+        /// </summary>
+        /// <param name="url">ScopeRegistry url to search for.</param>
+        /// <returns>`true` if scoped registry found, `false` otherwise.</returns>
+        public bool IsRegistryExists(string url)
+        {
+            return m_ScopeRegistries.ContainsKey(url);
+        }
+
+        /// <summary>
+        /// Searches for a specific dependency by the provided name.
+        /// </summary>
+        /// <param name="name">The dependency name to search for.</param>
+        /// <returns>`true` if found, `false` otherwise.</returns>
+        public bool IsDependencyExists(string name)
+        {
+            return m_Dependencies.ContainsKey(name);
+        }
+    }
+}

--- a/Editor/Core/Manifest.cs.meta
+++ b/Editor/Core/Manifest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 07fdbda8a8f0f7748ad8fde7d005cead
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Core/ScopeRegistry.cs
+++ b/Editor/Core/ScopeRegistry.cs
@@ -1,0 +1,121 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Com.OneSignal.Bootstrapper
+{
+    /// <summary>
+    /// Representation of "scopeRegistries" entry of the manifest file.
+    /// </summary>
+    class ScopeRegistry
+    {
+        const string k_KeyName = "name";
+        const string k_KeyUrl = "url";
+        const string k_KeyScopes = "scopes";
+
+        /// <summary>
+        /// Registry name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Registry url.
+        /// </summary>
+        public string Url { get; }
+
+        /// <summary>
+        /// Registry scopes.
+        /// </summary>
+        public HashSet<string> Scopes { get; }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ScopeRegistry"/> class with the provided properties.
+        /// </summary>
+        /// <param name="name">Name of new scope registry.</param>
+        /// <param name="url">Url of new scope registry.</param>
+        /// <param name="scopes">Scopes of new scope registry.</param>
+        public ScopeRegistry(string name, string url, HashSet<string> scopes)
+        {
+            Name = name;
+            Url = url;
+            Scopes = scopes;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ScopeRegistry"/> class with the provided data.
+        /// </summary>
+        /// <param name="dictionary">Data to fill this object. Must contain <see cref="k_KeyName">name</see>,
+        /// <see cref="k_KeyUrl">url</see> and <see cref="k_KeyScopes">scopes</see>.</param>
+        public ScopeRegistry(Dictionary<string, object> dictionary)
+        {
+            Name = (string) dictionary[k_KeyName];
+            Url = (string) dictionary[k_KeyUrl];
+            var scopes = (List<object>) dictionary[k_KeyScopes];
+            Scopes = new HashSet<string>();
+            foreach (var scope in scopes)
+            {
+                Scopes.Add((string) scope);
+            }
+        }
+
+        /// <summary>
+        /// Returns true if provided scope exists in current scope registry.
+        /// </summary>
+        /// <param name="scope">string scope to check if exists in this scope registry.</param>
+        /// <returns>'true' if this ScopeRegistry contains scope, `false` otherwise.</returns>
+        public bool HasScope(string scope)
+        {
+            return Scopes.Contains(scope);
+        }
+
+        /// <summary>
+        /// Adds scope.
+        /// </summary>
+        /// <param name="scope">A scope to add.</param>
+        public void AddScope(string scope)
+        {
+            if (!HasScope(scope))
+                Scopes.Add(scope);
+        }
+
+        /// <summary>
+        /// Generates a hash of this object data, excluding Name.
+        /// </summary>
+        /// <returns>Hash of this object.</returns>
+        public override int GetHashCode() {
+            int hash = 0;
+            if (!string.IsNullOrEmpty(Url)) hash ^= Url.GetHashCode();
+             if (Scopes != null) {
+                foreach (var scope in Scopes) {
+                    hash ^= scope.GetHashCode();
+                }
+            }
+            return hash;
+        }
+
+        /// <summary>
+        /// Method for matching entries, Name matching is not necessary.
+        /// </summary>
+        /// <param name="obj">Object to compare with.</param>
+        /// <returns>'true' if url and scopes match, 'false' otherwise.</returns>
+        public override bool Equals(object obj)
+        {
+            return obj is ScopeRegistry other &&
+                   Url == other.Url &&
+                   Scopes != null && other.Scopes != null &&
+                   new HashSet<string>(Scopes).SetEquals(other.Scopes);
+        }
+
+        /// <summary>
+        /// Creates dictionary from this object.
+        /// </summary>
+        /// <returns>ScopeRegistry object representation as Dictionary&lt;string, object&gt;.</returns>
+        public Dictionary<string, object> ToDictionary()
+        {
+            Dictionary<string,object> result = new Dictionary<string, object>();
+            result.Add(k_KeyName,Name);
+            result.Add(k_KeyUrl,Url);
+            result.Add(k_KeyScopes,Scopes.ToList());
+            return result;
+        }
+    }
+}

--- a/Editor/Core/ScopeRegistry.cs.meta
+++ b/Editor/Core/ScopeRegistry.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 37774d884d264e3ab17df4f7c2c06a4e
+timeCreated: 1589374940

--- a/Editor/Utilities.meta
+++ b/Editor/Utilities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 81aa9425647a4654bb76cbe4d8decb90
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Utilities/MiniJSON.cs
+++ b/Editor/Utilities/MiniJSON.cs
@@ -1,0 +1,585 @@
+/*
+ * Copyright (c) 2013 Calvin Rien
+ *
+ * Based on the JSON parser by Patrick van Bergen
+ * http://techblog.procurios.nl/k/618/news/view/14605/14863/How-do-I-write-my-own-parser-for-JSON.html
+ *
+ * Simplified it so that it doesn't throw exceptions
+ * and can be used in Unity iPhone with maximum code stripping.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+// Forked from  https://github.com/Jackyjjc/MiniJSON.cs
+// version: 6de00beb134bbab9d873033a48b32e4067ed0c25
+
+namespace OneSignalPush.MiniJSON
+{
+    // Example usage:
+    //
+    //  using UnityEngine;
+    //  using System.Collections;
+    //  using System.Collections.Generic;
+    //  using MiniJSON;
+    //
+    //  public class MiniJSONTest : MonoBehaviour {
+    //      void Start () {
+    //          var jsonString = "{ \"array\": [1.44,2,3], " +
+    //                          "\"object\": {\"key1\":\"value1\", \"key2\":256}, " +
+    //                          "\"string\": \"The quick brown fox \\\"jumps\\\" over the lazy dog \", " +
+    //                          "\"unicode\": \"\\u3041 Men\u00fa sesi\u00f3n\", " +
+    //                          "\"int\": 65536, " +
+    //                          "\"float\": 3.1415926, " +
+    //                          "\"bool\": true, " +
+    //                          "\"null\": null }";
+    //
+    //          var dict = Json.Deserialize(jsonString) as Dictionary<string,object>;
+    //
+    //          Debug.Log("deserialized: " + dict.GetType());
+    //          Debug.Log("dict['array'][0]: " + ((List<object>) dict["array"])[0]);
+    //          Debug.Log("dict['string']: " + (string) dict["string"]);
+    //          Debug.Log("dict['float']: " + (double) dict["float"]); // floats come out as doubles
+    //          Debug.Log("dict['int']: " + (long) dict["int"]); // ints come out as longs
+    //          Debug.Log("dict['unicode']: " + (string) dict["unicode"]);
+    //
+    //          var str = Json.Serialize(dict);
+    //
+    //          Debug.Log("serialized: " + str);
+    //      }
+    //  }
+
+    /// <summary>
+    /// This class encodes and decodes JSON strings.
+    /// Spec. details, see http://www.json.org/
+    ///
+    /// JSON uses Arrays and Objects. These correspond here to the datatypes IList and IDictionary.
+    /// All numbers are parsed to doubles.
+    /// </summary>
+    static class Json {
+        /// <summary>
+        /// Parses the string json into a value
+        /// </summary>
+        /// <param name="json">A JSON string.</param>
+        /// <returns>An List&lt;object&gt;, a Dictionary&lt;string, object&gt;, a double, an integer,a string, null, true, or false</returns>
+        public static object Deserialize(string json) {
+            // save the string for debug information
+            if (json == null) {
+                return null;
+            }
+
+            return Parser.Parse(json);
+        }
+
+        sealed class Parser : IDisposable {
+            const string WORD_BREAK = "{}[],:\"";
+
+            public static bool IsWordBreak(char c) {
+                return Char.IsWhiteSpace(c) || WORD_BREAK.IndexOf(c) != -1;
+            }
+
+            enum TOKEN {
+                NONE,
+                CURLY_OPEN,
+                CURLY_CLOSE,
+                SQUARED_OPEN,
+                SQUARED_CLOSE,
+                COLON,
+                COMMA,
+                STRING,
+                NUMBER,
+                TRUE,
+                FALSE,
+                NULL
+            };
+
+            StringReader json;
+
+            Parser(string jsonString) {
+                json = new StringReader(jsonString);
+            }
+
+            public static object Parse(string jsonString) {
+                using (var instance = new Parser(jsonString)) {
+                    return instance.ParseValue();
+                }
+            }
+
+            public void Dispose() {
+                json.Dispose();
+                json = null;
+            }
+
+            Dictionary<string, object> ParseObject() {
+                Dictionary<string, object> table = new Dictionary<string, object>();
+
+                // ditch opening brace
+                json.Read();
+
+                while (true) {
+                    switch (NextToken) {
+                    case TOKEN.NONE:
+                        return null;
+                    case TOKEN.COMMA:
+                        continue;
+                    case TOKEN.CURLY_CLOSE:
+                        return table;
+                    default:
+                        // name
+                        string name = ParseString();
+                        if (name == null) {
+                            return null;
+                        }
+
+                        // :
+                        if (NextToken != TOKEN.COLON) {
+                            return null;
+                        }
+                        // ditch the colon
+                        json.Read();
+
+                        // value
+                        table[name] = ParseValue();
+                        break;
+                    }
+                }
+            }
+
+            List<object> ParseArray() {
+                List<object> array = new List<object>();
+
+                // ditch opening bracket
+                json.Read();
+
+                // [
+                var parsing = true;
+                while (parsing) {
+                    TOKEN nextToken = NextToken;
+
+                    switch (nextToken) {
+                    case TOKEN.NONE:
+                        return null;
+                    case TOKEN.COMMA:
+                        continue;
+                    case TOKEN.SQUARED_CLOSE:
+                        parsing = false;
+                        break;
+                    default:
+                        object value = ParseByToken(nextToken);
+
+                        array.Add(value);
+                        break;
+                    }
+                }
+
+                return array;
+            }
+
+            object ParseValue() {
+                TOKEN nextToken = NextToken;
+                return ParseByToken(nextToken);
+            }
+
+            object ParseByToken(TOKEN token) {
+                switch (token) {
+                case TOKEN.STRING:
+                    return ParseString();
+                case TOKEN.NUMBER:
+                    return ParseNumber();
+                case TOKEN.CURLY_OPEN:
+                    return ParseObject();
+                case TOKEN.SQUARED_OPEN:
+                    return ParseArray();
+                case TOKEN.TRUE:
+                    return true;
+                case TOKEN.FALSE:
+                    return false;
+                case TOKEN.NULL:
+                    return null;
+                default:
+                    return null;
+                }
+            }
+
+            string ParseString() {
+                StringBuilder s = new StringBuilder();
+                char c;
+
+                // ditch opening quote
+                json.Read();
+
+                bool parsing = true;
+                while (parsing) {
+
+                    if (json.Peek() == -1) {
+                        break;
+                    }
+
+                    c = NextChar;
+                    switch (c) {
+                    case '"':
+                        parsing = false;
+                        break;
+                    case '\\':
+                        if (json.Peek() == -1) {
+                            parsing = false;
+                            break;
+                        }
+
+                        c = NextChar;
+                        switch (c) {
+                        case '"':
+                        case '\\':
+                        case '/':
+                            s.Append(c);
+                            break;
+                        case 'b':
+                            s.Append('\b');
+                            break;
+                        case 'f':
+                            s.Append('\f');
+                            break;
+                        case 'n':
+                            s.Append('\n');
+                            break;
+                        case 'r':
+                            s.Append('\r');
+                            break;
+                        case 't':
+                            s.Append('\t');
+                            break;
+                        case 'u':
+                            var hex = new char[4];
+
+                            for (int i=0; i< 4; i++) {
+                                hex[i] = NextChar;
+                            }
+
+                            s.Append((char) Convert.ToInt32(new string(hex), 16));
+                            break;
+                        default:
+                            s.Append(c);
+                            break;
+                        }
+                        break;
+                    default:
+                        s.Append(c);
+                        break;
+                    }
+                }
+
+                return s.ToString();
+            }
+
+            object ParseNumber() {
+                string number = NextWord;
+
+                if (number.IndexOf('.') == -1 && number.IndexOf('E') == -1 && number.IndexOf('e') == -1) {
+                    long parsedInt;
+                    Int64.TryParse(number, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out parsedInt);
+                    return parsedInt;
+                }
+
+                double parsedDouble;
+                Double.TryParse(number, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.InvariantCulture, out parsedDouble);
+                return parsedDouble;
+            }
+
+            void EatWhitespace() {
+                while (Char.IsWhiteSpace(PeekChar)) {
+                    json.Read();
+
+                    if (json.Peek() == -1) {
+                        break;
+                    }
+                }
+            }
+
+            char PeekChar {
+                get {
+                    return Convert.ToChar(json.Peek());
+                }
+            }
+
+            char NextChar {
+                get {
+                    return Convert.ToChar(json.Read());
+                }
+            }
+
+            string NextWord {
+                get {
+                    StringBuilder word = new StringBuilder();
+
+                    while (!IsWordBreak(PeekChar)) {
+                        word.Append(NextChar);
+
+                        if (json.Peek() == -1) {
+                            break;
+                        }
+                    }
+
+                    return word.ToString();
+                }
+            }
+
+            TOKEN NextToken {
+                get {
+                    EatWhitespace();
+
+                    if (json.Peek() == -1) {
+                        return TOKEN.NONE;
+                    }
+
+                    switch (PeekChar) {
+                    case '{':
+                        return TOKEN.CURLY_OPEN;
+                    case '}':
+                        json.Read();
+                        return TOKEN.CURLY_CLOSE;
+                    case '[':
+                        return TOKEN.SQUARED_OPEN;
+                    case ']':
+                        json.Read();
+                        return TOKEN.SQUARED_CLOSE;
+                    case ',':
+                        json.Read();
+                        return TOKEN.COMMA;
+                    case '"':
+                        return TOKEN.STRING;
+                    case ':':
+                        return TOKEN.COLON;
+                    case '0':
+                    case '1':
+                    case '2':
+                    case '3':
+                    case '4':
+                    case '5':
+                    case '6':
+                    case '7':
+                    case '8':
+                    case '9':
+                    case '-':
+                        return TOKEN.NUMBER;
+                    default:
+                        switch (NextWord) {
+                            case "false":
+                                return TOKEN.FALSE;
+                            case "true":
+                                return TOKEN.TRUE;
+                            case "null":
+                                return TOKEN.NULL;
+                            default:
+                                return TOKEN.NONE;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Converts a IDictionary / IList object or a simple type (string, int, etc.) into a JSON string
+        /// </summary>
+        /// <param name="json">A Dictionary&lt;string, object&gt; / List&lt;object&gt;</param>
+        /// <param name="humanReadable">Whether output as human readable format with spaces and
+        /// indentations.</param>
+        /// <param name="indentSpaces">Number of spaces for each level of indentation.</param>
+        /// <returns>A JSON encoded string, or null if object 'json' is not serializable</returns>
+        public static string Serialize(object obj,
+                                       bool humanReadable = false,
+                                       int indentSpaces = 2) {
+            return Serializer.MakeSerialization(obj, humanReadable, indentSpaces);
+        }
+
+        sealed class Serializer {
+            readonly StringBuilder builder;
+            readonly bool humanReadable;
+            readonly int indentSpaces;
+            int indentLevel;
+
+            Serializer(bool humanReadable, int indentSpaces) {
+                builder = new StringBuilder();
+                this.humanReadable = humanReadable;
+                this.indentSpaces = indentSpaces;
+                indentLevel = 0;
+            }
+
+            public static string MakeSerialization(object obj, bool humanReadable, int indentSpaces) {
+                var instance = new Serializer(humanReadable, indentSpaces);
+
+                instance.SerializeValue(obj);
+
+                return instance.builder.ToString();
+            }
+
+            void SerializeValue(object value) {
+                IList asList;
+                IDictionary asDict;
+                string asStr;
+
+                if (value == null) {
+                    builder.Append("null");
+                } else if ((asStr = value as string) != null) {
+                    SerializeString(asStr);
+                } else if (value is bool) {
+                    builder.Append((bool) value ? "true" : "false");
+                } else if ((asList = value as IList) != null) {
+                    SerializeArray(asList);
+                } else if ((asDict = value as IDictionary) != null) {
+                    SerializeObject(asDict);
+                } else if (value is char) {
+                    SerializeString(new string((char) value, 1));
+                } else {
+                    SerializeOther(value);
+                }
+            }
+
+            void AppendNewLineFunc() {
+                builder.AppendLine();
+                builder.Append(' ', indentSpaces * indentLevel);
+            }
+
+            void SerializeObject(IDictionary obj) {
+                bool first = true;
+
+                builder.Append('{');
+                ++indentLevel;
+
+                foreach (object e in obj.Keys) {
+                    if (first) {
+                        if (humanReadable) AppendNewLineFunc();
+                    } else {
+                        builder.Append(',');
+                        if (humanReadable) AppendNewLineFunc();
+                    }
+
+                    SerializeString(e.ToString());
+                    builder.Append(':');
+                    if (humanReadable) builder.Append(' ');
+
+                    SerializeValue(obj[e]);
+
+                    first = false;
+                }
+
+                --indentLevel;
+                if (humanReadable && obj.Count > 0) AppendNewLineFunc();
+
+                builder.Append('}');
+            }
+
+            void SerializeArray(IList anArray) {
+                builder.Append('[');
+                ++indentLevel;
+
+                bool first = true;
+
+                for (int i=0; i<anArray.Count; i++) {
+                    object obj = anArray[i];
+                    if (first) {
+                        if (humanReadable) AppendNewLineFunc();
+                    } else {
+                        builder.Append(',');
+                        if (humanReadable) AppendNewLineFunc();
+                    }
+
+                    SerializeValue(obj);
+
+                    first = false;
+                }
+
+                --indentLevel;
+                if (humanReadable && anArray.Count > 0) AppendNewLineFunc();
+
+                builder.Append(']');
+            }
+
+            void SerializeString(string str) {
+                builder.Append('\"');
+
+                char[] charArray = str.ToCharArray();
+                for (int i=0; i<charArray.Length; i++) {
+                    char c = charArray[i];
+                    switch (c) {
+                    case '"':
+                        builder.Append("\\\"");
+                        break;
+                    case '\\':
+                        builder.Append("\\\\");
+                        break;
+                    case '\b':
+                        builder.Append("\\b");
+                        break;
+                    case '\f':
+                        builder.Append("\\f");
+                        break;
+                    case '\n':
+                        builder.Append("\\n");
+                        break;
+                    case '\r':
+                        builder.Append("\\r");
+                        break;
+                    case '\t':
+                        builder.Append("\\t");
+                        break;
+                    default:
+                        int codepoint = Convert.ToInt32(c);
+                        if ((codepoint >= 32) && (codepoint <= 126)) {
+                            builder.Append(c);
+                        } else {
+                            builder.Append("\\u");
+                            builder.Append(codepoint.ToString("x4"));
+                        }
+                        break;
+                    }
+                }
+
+                builder.Append('\"');
+            }
+
+            void SerializeOther(object value) {
+                // NOTE: decimals lose precision during serialization.
+                // They always have, I'm just letting you know.
+                // Previously floats and doubles lost precision too.
+                if (value is float) {
+                    builder.Append(((float) value).ToString("R", System.Globalization.CultureInfo.InvariantCulture));
+                } else if (value is int
+                    || value is uint
+                    || value is long
+                    || value is sbyte
+                    || value is byte
+                    || value is short
+                    || value is ushort
+                    || value is ulong) {
+                    builder.Append(value);
+                } else if (value is double
+                    || value is decimal) {
+                    builder.Append(Convert.ToDouble(value).ToString("R", System.Globalization.CultureInfo.InvariantCulture));
+                } else {
+                    SerializeString(value.ToString());
+                }
+            }
+        }
+    }
+}

--- a/Editor/Utilities/MiniJSON.cs.meta
+++ b/Editor/Utilities/MiniJSON.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d72009a2475be35697639eaf34a7221
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,129 @@
+Modified MIT License
+
+Copyright 2020 OneSignal
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+1. The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+2. All copies of substantial portions of the Software may only be used in connection
+with services provided by OneSignal.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+Includes portions from the Google GcmClient demo project:
+    Copyright 2013 Google Inc.
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+      http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+Includes portions from RootTools:
+    Copyright (c) 2012 Stephen Erickson, Chris Ravenscroft, Dominik Schuermann, Adam Shanks
+    
+    This code is dual-licensed under the terms of the Apache License Version 2.0 and
+    the terms of the General Public License (GPL) Version 2.
+    You may use this code according to either of these licenses as is most appropriate
+    for your project on a case-by-case basis.
+    
+    The terms of each license can be found at:
+    
+    * http://www.apache.org/licenses/LICENSE-2.0
+    * http://www.gnu.org/licenses/gpl-2.0.txt
+     
+    Unless required by applicable law or agreed to in writing, software
+    distributed under these Licenses is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See each License for the specific language governing permissions and
+    limitations under that License.
+    
+Includes portions from DTTJailbreakDetection:    
+    The MIT License (MIT)
+
+    Copyright (c) 2014 Doan Truong Thi
+    
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Includes portions from BSMobileProvision:
+    Copyright (c) 2013, The Blindsight Corporation
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    
+Includes ShortcutBadger:
+    Unless required by applicable law or agreed to in writing, software
+    distributed under these Licenses is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See each License for the specific language governing permissions and
+    limitations under that License.
+
+    
+        Copyright 2014 Leo Lin
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+        
+    
+Includes unity-jar-resolver
+    Copyright (C) 2014 Google Inc.
+ 
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/LICENSE.md.meta
+++ b/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8665ee26ed0c040ab9fbbcec8e045300
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f018a844a98934ad38f0543635f3bbb8
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Third Party Notices.md
+++ b/Third Party Notices.md
@@ -1,0 +1,7 @@
+This package contains third-party software components governed by the license(s) indicated below:
+
+Component Name: MiniJSON.cs
+
+License Type: "MIT"
+
+[MiniJSON.cs License](https://github.com/Jackyjjc/MiniJSON.cs/blob/master/LICENCE)

--- a/Third Party Notices.md.meta
+++ b/Third Party Notices.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c1b529295889842d18e8df6569e15345
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "com.onesignal.unity.bootstrap",
+  "displayName": "OneSignal - Bootstrap",
+  "version": "1.0.0",
+  "unity": "2018.4",
+  "description": "OneSignal SDK Bootstrapper.",
+   "keywords": [
+     "push-notifications",
+     "notification-service",
+     "notifications",
+     "sdk",
+     "pushnotificaitions",
+     "apns",
+     "gcm",
+     "bootstrap"
+   ],
+   "license": "MIT",
+   "author": {
+     "name": "OneSignal",
+     "email": "support@onesignal.com",
+     "url": "https://onesignal.com/"
+   },
+
+   "homepage": "https://onesignal.com/",
+   "bugs": {
+     "url": "https://github.com/OneSignal/OneSignal-Unity-SDK-Bootstrap/issues",
+     "email" : "support@onesignal.com"
+   },
+   "repository": {
+     "type": "git",
+     "url": "git@github.com:OneSignal/OneSignal-Unity-SDK-Bootstrap.git"
+   }
+}

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a06aa03a9e1034a948486d6e2003c173
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
> When `com.onesignal.unity.bootstrap` is added to the project it will:
> 
> 1. Add following dependencies to the project `manifest.json`
>    
>    * `com.onesignal.unity.core`
>    * `com.onesignal.unity.ios`
>    * `com.onesignal.unity.android`
> 2. Add NPMJS OneSgianl Package Registry
> 
> ```
> "name": "npmjs",
> "url": "https://registry.npmjs.org/",
> "scopes": [
>      "com.onesignal"
>  ]
> ```
> 
> 1. Remove itself from the project
>    
>    * We want to keep user project as clean as possible
>    * We want users to be able to delete any of the installed products (bootstrapper will interfere if exists)
>    * Bootstrapper does not contain any public C# API and useless for the user.

Everything above + gitHub Actions `npm` release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-unity-sdk-bootstrap/2)
<!-- Reviewable:end -->
